### PR TITLE
fix the warning when read excel

### DIFF
--- a/akshare/stock/stock_info.py
+++ b/akshare/stock/stock_info.py
@@ -9,7 +9,7 @@ from io import BytesIO
 
 import pandas as pd
 import requests
-
+import warnings
 
 def stock_info_sz_name_code(indicator: str = "A股列表") -> pd.DataFrame:
     """
@@ -29,7 +29,9 @@ def stock_info_sz_name_code(indicator: str = "A股列表") -> pd.DataFrame:
          "random": "0.6935816432433362",
     }
     r = requests.get(url, params=params)
-    temp_df = pd.read_excel(BytesIO(r.content), engine="xlrd")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        temp_df = pd.read_excel(BytesIO(r.content), engine="openpyxl")
     if len(temp_df) > 10:
         if indicator == "A股列表":
             temp_df["A股代码"] = temp_df["A股代码"].astype(str).str.split('.', expand=True).iloc[:, 0].str.zfill(6).str.replace("000nan", "")


### PR DESCRIPTION
If use xlrd, it will always say:
FutureWarning: Your version of xlrd is 1.2.0. In xlrd >= 2.0, only the xls format is supported. As a result, the openpyxl engine will be used if it is installed and the engine argument is not specified. Install openpyxl instead.

If change to openpyxl, it will say:
UserWarning: Workbook contains no default style, apply openpyxl's default

Then import warnings to disable the warning.

Warning will break pytest, that's why I hope to resolve it.